### PR TITLE
Add Bucket

### DIFF
--- a/aind-landing-Page/public/tools-data.yaml
+++ b/aind-landing-Page/public/tools-data.yaml
@@ -568,6 +568,18 @@ domains:
       - Product
       verified: false
       website_url: https://github.com/stackblitz-labs/bolt.diy
+    - date_added: 09/04/2025
+      description: Flag features, manage company data, and control feature access from your favorite AI code editor using Bucket.
+      icon_url: https://images.crunchbase.com/image/upload/c_pad,h_170,w_170,f_auto,b_white,q_auto:eco,dpr_2/b7fb4655e87a46dba7f73e73b921fb0d
+      name: Bucket.co
+      oss: false
+      popular: false
+      tags:
+      - GA
+      - Prototyping
+      - Product
+      verified: false
+      website_url: https://bucket.co
     - date_added: 12/03/2025
       description: Every team can use Claude to create high-quality work products
         faster than ever before. From code snippets and flowcharts to SVG graphics,


### PR DESCRIPTION
This PR adds [Bucket.co](https://bucket.co) to the Prototyping category. Bucket is a feature flagging tool for React, Node.js, and Next.js.