### PR TITLE
Add Metoro to SRE section

### DIFF
--- a/aind-landing-Page/public/tools-data.yaml
+++ b/aind-landing-Page/public/tools-data.yaml
@@ -4486,6 +4486,19 @@ domains:
       - DevOps
       verified: false
       website_url: https://www.wildmoose.ai/
+    - date_added: 28/01/2026
+      description: AI SRE for Kubernetes. Autonomous issue detection, root cause
+        analysis, and remediation.
+      icon_url: https://metoro.io/favicon.ico
+      name: Metoro
+      oss: false
+      popular: false
+      tags:
+      - GA
+      - SRE
+      - DevOps
+      verified: false
+      website_url: https://metoro.io/
     - date_added: 23/05/2025
       description: The R&P lab reimagining DevOps
       icon_url: https://www.a37.ai/favicon.svg


### PR DESCRIPTION
Hey there, just wanted to add Metoro to the list here :) We do AI SRE

Thanks for your time!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Metoro (AI SRE for Kubernetes) to the SRE tools list in `public/tools-data.yaml`.
> 
> - New entry with `date_added` 28/01/2026, description, icon URL, website, and tags (`GA`, `SRE`, `DevOps`); `oss: false`, `popular: false`, `verified: false`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c456cfd510c6eb9eb666a0bfae9628cb5268349c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->